### PR TITLE
Add clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,25 @@
+  Checks: >
+    -*,
+    bugprone-*,
+    -bugprone-easily-swappable-parameters,
+    -bugprone-reserved-identifier,
+    clang-analyzer-*,
+    -clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling,
+    misc-*,
+    -misc-no-recursion,
+    performance-*,
+    portability-*,
+    readability-*,
+    -readability-braces-around-statements,
+    -readability-function-cognitive-complexity,
+    -readability-identifier-length,
+    -readability-magic-numbers,
+    -readability-avoid-const-params-in-decls
+
+  WarningsAsErrors: ''
+
+  HeaderFilterRegex: '.*(src|test|examples)/.*'
+
+  ExcludeHeaderFilterRegex: '.*(third_party|external)/.*'
+
+  FormatStyle: file

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,25 +1,27 @@
-  Checks: >
-    -*,
-    bugprone-*,
-    -bugprone-easily-swappable-parameters,
-    -bugprone-reserved-identifier,
-    clang-analyzer-*,
-    -clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling,
-    misc-*,
-    -misc-no-recursion,
-    performance-*,
-    portability-*,
-    readability-*,
-    -readability-braces-around-statements,
-    -readability-function-cognitive-complexity,
-    -readability-identifier-length,
-    -readability-magic-numbers,
-    -readability-avoid-const-params-in-decls
+Checks: >
+  -*,
+  bugprone-*,
+  -bugprone-easily-swappable-parameters,
+  -bugprone-reserved-identifier,
+  clang-analyzer-*,
+  -clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling,
+  misc-*,
+  -misc-no-recursion,
+  performance-*,
+  portability-*,
+  readability-*,
+  -readability-braces-around-statements,
+  -readability-function-cognitive-complexity,
+  -readability-identifier-length,
+  -readability-magic-numbers,
+  -readability-avoid-const-params-in-decls,
+  -readability-implicit-bool-conversion,
+  -clang-diagnostic-*
 
-  WarningsAsErrors: ''
+WarningsAsErrors: ''
 
-  HeaderFilterRegex: '.*(src|test|examples)/.*'
+HeaderFilterRegex: '.*(src|test|examples)/.*'
 
-  ExcludeHeaderFilterRegex: '.*(third_party|external)/.*'
+ExcludeHeaderFilterRegex: '.*template\.h$'
 
-  FormatStyle: file
+FormatStyle: file

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,13 +18,11 @@ jobs:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
           nix_path: nixpkgs=channel:nixos-unstable
       - name: CMake
-        run: nix-shell --run 'cmake -S . -B build -GNinja -DDEVELOP=On -DCMAKE_EXPORT_COMPILE_COMMANDS=ON'
+        run: nix-shell --run 'cmake -S . -B build -GNinja'
       - name: Build
         run: nix-shell --run 'ninja -C build'
       - name: Test
         run: nix-shell --run 'ctest --test-dir build --output-on-failure'
-      - name: Format Check
-        run: nix-shell --run 'ninja -C build format-check'  
       - name: Test Coverage
         run: nix-shell --run 'ninja -C build coverage'
       - name: Upload all coverage artifacts

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,10 +5,8 @@ project(derivec_project C CXX)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # NOTE: Want latest cpp for testing/benchmark, but the derive-c library to be usable for C99 codebases
-# set (CMAKE_CXX_STANDARD 23)
-# set (CMAKE_C_STANDARD 99)
 
-set( CMAKE_C_STANDARD            99           CACHE STRING "C standard"        FORCE )
+set( CMAKE_C_STANDARD            23           CACHE STRING "C standard"        FORCE )
 set( CMAKE_C_STANDARD_REQUIRED   ON           CACHE BOOL   "Require C std"     FORCE )
 set( CMAKE_C_EXTENSIONS          OFF          CACHE BOOL   "No compiler extensions" FORCE )
 
@@ -75,28 +73,36 @@ if(CLANG_FORMAT)
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
         COMMENT "Verifying clang-format compliance (fails if any file needs reformatting)"
     )
+
+    add_test(NAME format-check COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --target format-check)
 endif()
 
 find_program(CLANG_TIDY NAMES clang-tidy)
 
 if(CLANG_TIDY)
-  # C: examples/ sources only (since src/ is header-only)
+  message(STATUS "Found clang-tidy: ${CLANG_TIDY}")
   file(GLOB_RECURSE TIDY_C_SRC  "${CMAKE_SOURCE_DIR}/examples/*.c")
-  # Headers: both src/ and examples/
   file(GLOB_RECURSE TIDY_C_HDRS "${CMAKE_SOURCE_DIR}/src/*.h" "${CMAKE_SOURCE_DIR}/examples/*.h")
-
-  # C++: test/
   file(GLOB_RECURSE TIDY_CPP "${CMAKE_SOURCE_DIR}/test/*.cpp")
+
+  # Get the resource directory from the compiler
+  execute_process(
+    COMMAND ${CMAKE_C_COMPILER} -print-resource-dir
+    OUTPUT_VARIABLE CLANG_RESOURCE_DIR
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  
+  message(STATUS "Clang resource directory: ${CLANG_RESOURCE_DIR}")
 
   # Create separate targets for sources and headers
   if(TIDY_C_SRC)
     add_custom_target(lint-c-src
-      COMMAND ${CLANG_TIDY} -p ${CMAKE_BINARY_DIR} --quiet --extra-arg-before=-xc ${TIDY_C_SRC}
+      COMMAND ${CLANG_TIDY} -p ${CMAKE_BINARY_DIR} --quiet --extra-arg=-resource-dir=${CLANG_RESOURCE_DIR} ${TIDY_C_SRC}
       WORKING_DIRECTORY ${CMAKE_SOURCE_DIR} VERBATIM)
   endif()
 
   add_custom_target(lint-c-hdrs
-    COMMAND ${CLANG_TIDY} -p ${CMAKE_BINARY_DIR} --quiet --extra-arg-before=-xc --header-filter="^${CMAKE_SOURCE_DIR}/src/" ${TIDY_C_HDRS}
+    COMMAND ${CLANG_TIDY} -p ${CMAKE_BINARY_DIR} --quiet --extra-arg-before=-xc --extra-arg=-resource-dir=${CLANG_RESOURCE_DIR} --header-filter="^${CMAKE_SOURCE_DIR}/src/" ${TIDY_C_HDRS}
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR} VERBATIM)
 
   if(TIDY_C_SRC)
@@ -105,29 +111,5 @@ if(CLANG_TIDY)
     add_custom_target(lint-c DEPENDS lint-c-hdrs)
   endif()
 
-  add_custom_target(lint-cpp
-    COMMAND ${CLANG_TIDY} -p ${CMAKE_BINARY_DIR} --quiet --header-filter="^${CMAKE_SOURCE_DIR}/test/" ${TIDY_CPP}
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR} VERBATIM)
-
-  add_custom_target(lint DEPENDS lint-c lint-cpp)
+  add_test(NAME lint-c COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --target lint-c)
 endif()
-# if(CLANG_TIDY)
-#   file(GLOB_RECURSE ALL_SRC
-#     "${CMAKE_SOURCE_DIR}/src/*.cpp"
-#     "${CMAKE_SOURCE_DIR}/test/*.cpp"
-#     "${CMAKE_SOURCE_DIR}/examples/*.cpp"
-#   )
-
-#   add_custom_target(lint
-#     COMMAND ${CLANG_TIDY}
-#             -p ${CMAKE_BINARY_DIR}
-#             --header-filter "^${CMAKE_SOURCE_DIR}/(src|test|examples)/"
-#             # Suppress diagnostics for all deps
-#             --extra-arg-before=--system-header-prefix=${CMAKE_BINARY_DIR}/_deps/
-#              --extra-arg-before=-isystem${CMAKE_BINARY_DIR}/_deps/rapidcheck-src/include
-#             ${ALL_SRC}
-#     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-#     COMMENT "Running clang-tidy on project sources"
-#     VERBATIM
-#   )
-# endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.30)
 project(derivec_project C CXX)
 
+# Export compilation commands for clang-tidy and other tools
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 # NOTE: Want latest cpp for testing/benchmark, but the derive-c library to be usable for C99 codebases
 # set (CMAKE_CXX_STANDARD 23)
 # set (CMAKE_C_STANDARD 99)
@@ -13,7 +16,7 @@ set( CMAKE_CXX_STANDARD          23           CACHE STRING "C++ standard"      F
 set( CMAKE_CXX_STANDARD_REQUIRED ON           CACHE BOOL   "Require C++ std"   FORCE )
 set( CMAKE_CXX_EXTENSIONS        OFF          CACHE BOOL   "No compiler extensions" FORCE )
 
-option(DEVELOP "Enable debug + coverage + sanitizers build" OFF)
+option(DEVELOP "Enable debug + coverage + sanitizers build" ON)
 option(EXTERNALS "Include targets using externals" ON)
 
 if (DEVELOP)
@@ -73,3 +76,58 @@ if(CLANG_FORMAT)
         COMMENT "Verifying clang-format compliance (fails if any file needs reformatting)"
     )
 endif()
+
+find_program(CLANG_TIDY NAMES clang-tidy)
+
+if(CLANG_TIDY)
+  # C: examples/ sources only (since src/ is header-only)
+  file(GLOB_RECURSE TIDY_C_SRC  "${CMAKE_SOURCE_DIR}/examples/*.c")
+  # Headers: both src/ and examples/
+  file(GLOB_RECURSE TIDY_C_HDRS "${CMAKE_SOURCE_DIR}/src/*.h" "${CMAKE_SOURCE_DIR}/examples/*.h")
+
+  # C++: test/
+  file(GLOB_RECURSE TIDY_CPP "${CMAKE_SOURCE_DIR}/test/*.cpp")
+
+  # Create separate targets for sources and headers
+  if(TIDY_C_SRC)
+    add_custom_target(lint-c-src
+      COMMAND ${CLANG_TIDY} -p ${CMAKE_BINARY_DIR} --quiet --extra-arg-before=-xc ${TIDY_C_SRC}
+      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR} VERBATIM)
+  endif()
+
+  add_custom_target(lint-c-hdrs
+    COMMAND ${CLANG_TIDY} -p ${CMAKE_BINARY_DIR} --quiet --extra-arg-before=-xc --header-filter="^${CMAKE_SOURCE_DIR}/src/" ${TIDY_C_HDRS}
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR} VERBATIM)
+
+  if(TIDY_C_SRC)
+    add_custom_target(lint-c DEPENDS lint-c-src lint-c-hdrs)
+  else()
+    add_custom_target(lint-c DEPENDS lint-c-hdrs)
+  endif()
+
+  add_custom_target(lint-cpp
+    COMMAND ${CLANG_TIDY} -p ${CMAKE_BINARY_DIR} --quiet --header-filter="^${CMAKE_SOURCE_DIR}/test/" ${TIDY_CPP}
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR} VERBATIM)
+
+  add_custom_target(lint DEPENDS lint-c lint-cpp)
+endif()
+# if(CLANG_TIDY)
+#   file(GLOB_RECURSE ALL_SRC
+#     "${CMAKE_SOURCE_DIR}/src/*.cpp"
+#     "${CMAKE_SOURCE_DIR}/test/*.cpp"
+#     "${CMAKE_SOURCE_DIR}/examples/*.cpp"
+#   )
+
+#   add_custom_target(lint
+#     COMMAND ${CLANG_TIDY}
+#             -p ${CMAKE_BINARY_DIR}
+#             --header-filter "^${CMAKE_SOURCE_DIR}/(src|test|examples)/"
+#             # Suppress diagnostics for all deps
+#             --extra-arg-before=--system-header-prefix=${CMAKE_BINARY_DIR}/_deps/
+#              --extra-arg-before=-isystem${CMAKE_BINARY_DIR}/_deps/rapidcheck-src/include
+#             ${ALL_SRC}
+#     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+#     COMMENT "Running clang-tidy on project sources"
+#     VERBATIM
+#   )
+# endif()

--- a/README.md
+++ b/README.md
@@ -31,10 +31,15 @@ cmake -S . -B build -GNinja -DDEVELOP=On -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 cd build
 ninja
 ninja format
+ninja lint
 ninja docs
 ninja coverage
 
 ctest # includes examples/ as well as test/
+```
+Then when opening vscode from the nix-shell, the correct clangd & library paths are used:
+```bash
+code .
 ```
 
 For using `infer`, infer must be installed separately (it is not yet packaged with nix - [see here](https://github.com/NixOS/nixpkgs/issues/148048))

--- a/examples/complex/prime_sieve.c
+++ b/examples/complex/prime_sieve.c
@@ -3,7 +3,7 @@
  * @example complex/prime_sieve.c
  * @brief Using a vector in implementing a basic prime sieve.
  */
-#include <errno.h>
+// #include <errno.h>
 #include <limits.h>
 #include <stdbool.h>
 #include <stdio.h>
@@ -17,14 +17,19 @@ size_t sqrt_size_t(size_t n) {
     if (n == 0 || n == 1) {
         return n;
     }
-    size_t left = 1, right = n, mid, result = 0;
+    size_t left = 1;
+    size_t right = n;
+    size_t mid;
+    size_t result = 0;
     while (left <= right) {
         mid = left + (right - left) / 2;
         size_t square = mid * mid;
 
         if (square == n) {
             return mid;
-        } else if (square < n) {
+        }
+
+        if (square < n) {
             result = mid; // Store the last valid result
             left = mid + 1;
         } else {

--- a/examples/derives/derives.c
+++ b/examples/derives/derives.c
@@ -1,4 +1,5 @@
 #include <assert.h>
+#include <stdint.h>
 
 #include <derive-c/derives/clone.h>
 #include <derive-c/derives/eq.h>

--- a/examples/structures/hashmap.c
+++ b/examples/structures/hashmap.c
@@ -43,8 +43,8 @@ void id_to_name_example() {
 
     print_map(&map);
 
-    char const** entry;
-    ASSERT((entry = id_to_name_write(&map, 23)));
+    char const** entry = id_to_name_write(&map, 23);
+    ASSERT(entry);
     *entry = "a different string!";
 
     print_map(&map);

--- a/examples/structures/staticvec.c
+++ b/examples/structures/staticvec.c
@@ -4,6 +4,7 @@
 
 #include <assert.h>
 #include <stdint.h>
+#include <stdio.h>
 
 #define MAX_CAPACITY 8
 

--- a/examples/structures/vector.c
+++ b/examples/structures/vector.c
@@ -3,7 +3,11 @@
 /// @brief Examples for inserting, iterating, and deleting from vectors.
 
 #include <assert.h>
+#include <stddef.h>
 #include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #define T int32_t
 #define SELF vec_ints
@@ -35,38 +39,38 @@ void ints_example() {
     vec_ints_delete(&ints);
 }
 
-struct complex {
+struct complex_data {
     char* description;
     size_t score;
 };
 
-void complex_delete(struct complex* self) { free(self->description); }
+void complex_data_delete(struct complex_data* self) { free(self->description); }
 
-#define T struct complex
-#define T_DELETE complex_delete
-#define SELF vec_complex
+#define T struct complex_data
+#define T_DELETE complex_data_delete
+#define SELF vec_complex_data
 #include <derive-c/structures/vector/template.h>
 
-void complex_example() {
-    vec_complex vec = vec_complex_new_with_capacity(5);
+void complex_data_example() {
+    vec_complex_data vec = vec_complex_data_new_with_capacity(5);
     size_t entries = 5;
     for (size_t i = 0; i < entries; i++) {
-        struct complex item = {.description = strdup("Complex item"), .score = i * 10};
-        vec_complex_push(&vec, item);
+        struct complex_data item = {.description = strdup("Complex item"), .score = i * 10};
+        vec_complex_data_push(&vec, item);
     }
 
-    assert(vec_complex_size(&vec) == entries);
+    assert(vec_complex_data_size(&vec) == entries);
 
-    struct complex* first_item = vec_complex_write(&vec, 0);
+    struct complex_data* first_item = vec_complex_data_write(&vec, 0);
     first_item->score += 5;
 
-    assert(vec_complex_read(&vec, 0)->score == 5);
+    assert(vec_complex_data_read(&vec, 0)->score == 5);
 
-    struct complex popped = vec_complex_pop(&vec);
+    struct complex_data popped = vec_complex_data_pop(&vec);
     assert(popped.score == 40); // Last item's score should be 40
 
-    vec_complex_delete(&vec);
-    complex_delete(&popped);
+    vec_complex_data_delete(&vec);
+    complex_data_delete(&popped);
 }
 
 #define T char
@@ -114,6 +118,6 @@ void iterate_example() {
 
 int main() {
     ints_example();
-    complex_example();
+    complex_data_example();
     iterate_example();
 }

--- a/shell.nix
+++ b/shell.nix
@@ -16,7 +16,6 @@ myStdenv.mkDerivation {
       doxygen
       graphviz
       lcov
-      gcovr
     ])
     ++ (with llvm19; [
       clang        # clang-19

--- a/src/derive-c/core.h
+++ b/src/derive-c/core.h
@@ -8,11 +8,13 @@
 
 #define EXPAND(...) __VA_ARGS__
 
-typedef struct {
 #ifdef __cplusplus
+struct gdb_marker {
     char _dummy_cpp_object_size_compatibility __attribute__((unused));
+};
+#else
+typedef struct {} gdb_marker;
 #endif
-} gdb_marker;
 
 static inline size_t next_power_of_2(size_t x) {
     if (x == 0)

--- a/src/derive-c/core.h
+++ b/src/derive-c/core.h
@@ -13,7 +13,8 @@ struct gdb_marker {
     char _dummy_cpp_object_size_compatibility __attribute__((unused));
 };
 #else
-typedef struct {} gdb_marker;
+typedef struct {
+} gdb_marker;
 #endif
 
 static inline size_t next_power_of_2(size_t x) {

--- a/src/derive-c/derives/struct.h
+++ b/src/derive-c/derives/struct.h
@@ -13,4 +13,4 @@
 #define DERIVE_STRUCT(ID)                                                                          \
     typedef struct {                                                                               \
         NAME(ID, REFLECT)(DERIVE_STRUCT_MEMBER)                                                    \
-    } ID;
+    } (ID);

--- a/src/derive-c/derives/struct.h
+++ b/src/derive-c/derives/struct.h
@@ -13,4 +13,4 @@
 #define DERIVE_STRUCT(ID)                                                                          \
     typedef struct {                                                                               \
         NAME(ID, REFLECT)(DERIVE_STRUCT_MEMBER)                                                    \
-    } (ID);
+    }(ID);

--- a/src/derive-c/panic.h
+++ b/src/derive-c/panic.h
@@ -1,9 +1,10 @@
-#ifndef PANIC
-
+// JUSTIFY: No guards, just for each macro
+//           - allows overriding panic, differently for each template instantiation
 #include <assert.h>
-#include <stdio.h>
 #include <stdlib.h>
 
+#ifndef PANIC
+#include <stdio.h> // NOLINT(misc-include-cleaner) (for default panic implementation)
 #define PANIC(...)                                                                                 \
     do {                                                                                           \
         fprintf(stderr, __VA_ARGS__);                                                              \

--- a/src/derive-c/self.h
+++ b/src/derive-c/self.h
@@ -1,5 +1,7 @@
 
 #ifndef SELF
+#ifndef __clang_analyzer__
 #error "The name to use for the instantiation of the template must be defined"
+#endif
 #define SELF derive_c_parameter
 #endif

--- a/src/derive-c/structures/arena/template.h
+++ b/src/derive-c/structures/arena/template.h
@@ -21,7 +21,7 @@ typedef struct {
     int x;
 } derive_c_parameter_value;
 #define V derive_c_parameter_value
-void derive_c_parameter_value_delete(derive_c_parameter_value*) {}
+void derive_c_parameter_value_delete(derive_c_parameter_value* key __attribute__((unused))) {}
 #define V_DELETE derive_c_parameter_value_delete
 #endif
 
@@ -54,7 +54,7 @@ void derive_c_parameter_value_delete(derive_c_parameter_value*) {}
 
 #define SLOT NAME(SELF, SLOT)
 
-#define CHECK_ACCESS_INDEX(self, index) (index.index < self->exclusive_end)
+#define CHECK_ACCESS_INDEX(self, index) ((index).index < (self)->exclusive_end)
 
 // JUSTIFY: Macro rather than static
 //           - Avoids the need to cast to the INDEX_TYPE
@@ -223,9 +223,8 @@ static bool NAME(SELF, try_remove)(SELF* self, INDEX index, V* destination) {
         self->free_list = index.index;
         self->count--;
         return true;
-    } else {
-        return false;
     }
+    return false;
 }
 
 static V NAME(SELF, remove)(SELF* self, INDEX index) {

--- a/src/derive-c/structures/arena/template.h
+++ b/src/derive-c/structures/arena/template.h
@@ -11,12 +11,16 @@
 #include <derive-c/self.h>
 
 #ifndef INDEX_BITS
+#ifndef __clang_analyzer__
 #error "The number of bits (8,16,32,64) to use for the arena's key"
+#endif
 #define INDEX_BITS 32
 #endif
 
 #ifndef V
+#ifndef __clang_analyzer__
 #error "The value type to place in the arena must be defined"
+#endif
 typedef struct {
     int x;
 } derive_c_parameter_value;
@@ -26,7 +30,7 @@ void derive_c_parameter_value_delete(derive_c_parameter_value* key __attribute__
 #endif
 
 #ifndef V_DELETE
-#define V_DELETE(value)
+#define V_DELETE(value) (void)value
 #endif
 
 #if INDEX_BITS == 8
@@ -116,7 +120,7 @@ static INDEX NAME(SELF, insert)(SELF* self, V value) {
     if (self->free_list != INDEX_NONE) {
         INDEX_TYPE free_index = self->free_list;
         SLOT* slot = &self->slots[free_index];
-        DEBUG_ASSERT(!SLOT->present);
+        DEBUG_ASSERT(!slot->present);
         self->free_list = slot->next_free;
         slot->present = true;
         slot->value = value;
@@ -278,18 +282,17 @@ static IV_PAIR const* NAME(ITER, next)(ITER* iter) {
 
     if (NAME(ITER, empty)(iter)) {
         return NULL;
-    } else {
-        iter->curr = (IV_PAIR){.index = (INDEX){.index = iter->next_index},
-                               .value = &iter->arena->slots[iter->next_index].value};
-        iter->next_index++;
-        while (iter->next_index < INDEX_NONE && iter->next_index < iter->arena->exclusive_end &&
-               !iter->arena->slots[iter->next_index].present) {
-            iter->next_index++;
-        }
-
-        iter->pos++;
-        return &iter->curr;
     }
+    iter->curr = (IV_PAIR){.index = (INDEX){.index = iter->next_index},
+                           .value = &iter->arena->slots[iter->next_index].value};
+    iter->next_index++;
+    while (iter->next_index < INDEX_NONE && iter->next_index < iter->arena->exclusive_end &&
+           !iter->arena->slots[iter->next_index].present) {
+        iter->next_index++;
+    }
+
+    iter->pos++;
+    return &iter->curr;
 }
 
 static size_t NAME(ITER, position)(ITER const* iter) {
@@ -355,18 +358,18 @@ static IV_PAIR_CONST const* NAME(ITER_CONST, next)(ITER_CONST* iter) {
 
     if (NAME(ITER_CONST, empty)(iter)) {
         return NULL;
-    } else {
-        iter->curr = (IV_PAIR_CONST){.index = (INDEX){.index = iter->next_index},
-                                     .value = &iter->arena->slots[iter->next_index].value};
-        iter->next_index++;
-        while (iter->next_index != INDEX_NONE && iter->next_index < iter->arena->exclusive_end &&
-               !iter->arena->slots[iter->next_index].present) {
-            iter->next_index++;
-        }
-
-        iter->pos++;
-        return &iter->curr;
     }
+
+    iter->curr = (IV_PAIR_CONST){.index = (INDEX){.index = iter->next_index},
+                                 .value = &iter->arena->slots[iter->next_index].value};
+    iter->next_index++;
+    while (iter->next_index != INDEX_NONE && iter->next_index < iter->arena->exclusive_end &&
+           !iter->arena->slots[iter->next_index].present) {
+        iter->next_index++;
+    }
+
+    iter->pos++;
+    return &iter->curr;
 }
 
 static size_t NAME(ITER_CONST, position)(ITER_CONST const* iter) {

--- a/src/derive-c/structures/hashmap/hashers.h
+++ b/src/derive-c/structures/hashmap/hashers.h
@@ -10,7 +10,7 @@
 
 /// The worst possible hash, for testing purposes.
 #define ALWAYS_COLLIDE(type)                                                                       \
-    static size_t hash_always_collide_##type(type const* key) { return 0; }
+    static size_t hash_always_collide_##type(type const* key __attribute__((unused))) { return 0; }
 
 /// No hashing, just returns the integer value.
 /// For most circumstances with a key as a single integer, this is a good option.
@@ -68,7 +68,8 @@ size_t hash_murmurhash_string(const char* str) {
     _apply(5)                \
     _apply(6)                \
     _apply(7)                \
-    _apply(8) // clang-format on
+    _apply(8)
+// clang-format on
 
 #define MURMURHASH_STRING_FIXED_SIZE(size)                                                         \
     static size_t hash_murmurhash_string_##size(const char str[size]) {                            \

--- a/src/derive-c/structures/hashmap/murmurhash.h
+++ b/src/derive-c/structures/hashmap/murmurhash.h
@@ -242,7 +242,8 @@ void derive_c_MurmurHash3_x86_128(const void* key, const int32_t len, uint32_t s
     ((uint32_t*)out)[3] = h4;
 }
 
-void derive_c_MurmurHash3_x64_128(const void* key, const int32_t len, const uint32_t seed, void* out) {
+void derive_c_MurmurHash3_x64_128(const void* key, const int32_t len, const uint32_t seed,
+                                  void* out) {
     const uint8_t* data = (const uint8_t*)key;
     const int32_t nblocks = len / 16;
 

--- a/src/derive-c/structures/hashmap/murmurhash.h
+++ b/src/derive-c/structures/hashmap/murmurhash.h
@@ -2,15 +2,16 @@
 /// implementation](https://github.com/aappleby/smhasher/blob/master/src/MurmurHash3.h)
 
 #include <derive-c/core.h>
+#include <stddef.h>
 #include <stdint.h>
 
 FORCE_INLINE uint32_t derive_c_rotl32(uint32_t x, int8_t r) { return (x << r) | (x >> (32 - r)); }
 
 FORCE_INLINE uint64_t derive_c_rotl64(uint64_t x, int8_t r) { return (x << r) | (x >> (64 - r)); }
 
-FORCE_INLINE uint32_t derive_c_getblock32(const uint32_t* p, int i) { return p[i]; }
+FORCE_INLINE uint32_t derive_c_getblock32(const uint32_t* p, int32_t i) { return p[i]; }
 
-FORCE_INLINE uint64_t derive_c_getblock64(const uint64_t* p, int i) { return p[i]; }
+FORCE_INLINE uint64_t derive_c_getblock64(const uint64_t* p, int32_t i) { return p[i]; }
 
 FORCE_INLINE uint32_t derive_c_fmix32(uint32_t h) {
     h ^= h >> 16;
@@ -32,9 +33,9 @@ FORCE_INLINE uint64_t derive_c_fmix64(uint64_t k) {
     return k;
 }
 
-void derive_c_MurmurHash3_x86_32(const void* key, int len, uint32_t seed, void* out) {
+void derive_c_MurmurHash3_x86_32(const void* key, int32_t len, uint32_t seed, void* out) {
     const uint8_t* data = (const uint8_t*)key;
-    const int nblocks = len / 4;
+    const int32_t nblocks = len / 4;
 
     uint32_t h1 = seed;
 
@@ -43,7 +44,7 @@ void derive_c_MurmurHash3_x86_32(const void* key, int len, uint32_t seed, void* 
 
     // body
 
-    const uint32_t* blocks = (const uint32_t*)(data + nblocks * 4);
+    const uint32_t* blocks = (const uint32_t*)(data + (ptrdiff_t)(nblocks * 4));
 
     for (int i = -nblocks; i; i++) {
         uint32_t k1 = derive_c_getblock32(blocks, i);
@@ -59,7 +60,7 @@ void derive_c_MurmurHash3_x86_32(const void* key, int len, uint32_t seed, void* 
 
     // tail
 
-    const uint8_t* tail = (const uint8_t*)(data + nblocks * 4);
+    const uint8_t* tail = (const uint8_t*)(data + (ptrdiff_t)(nblocks * 4));
 
     uint32_t k1 = 0;
 
@@ -74,6 +75,7 @@ void derive_c_MurmurHash3_x86_32(const void* key, int len, uint32_t seed, void* 
         k1 = derive_c_rotl32(k1, 15);
         k1 *= c2;
         h1 ^= k1;
+    default:
     };
 
     // finalization
@@ -85,9 +87,9 @@ void derive_c_MurmurHash3_x86_32(const void* key, int len, uint32_t seed, void* 
     *(uint32_t*)out = h1;
 }
 
-void derive_c_MurmurHash3_x86_128(const void* key, const int len, uint32_t seed, void* out) {
+void derive_c_MurmurHash3_x86_128(const void* key, const int32_t len, uint32_t seed, void* out) {
     const uint8_t* data = (const uint8_t*)key;
-    const int nblocks = len / 16;
+    const int32_t nblocks = len / 16;
 
     uint32_t h1 = seed;
     uint32_t h2 = seed;
@@ -101,13 +103,13 @@ void derive_c_MurmurHash3_x86_128(const void* key, const int len, uint32_t seed,
 
     // body
 
-    const uint32_t* blocks = (const uint32_t*)(data + nblocks * 16);
+    const uint32_t* blocks = (const uint32_t*)(data + (ptrdiff_t)(nblocks * 16));
 
     for (int i = -nblocks; i; i++) {
-        uint32_t k1 = derive_c_getblock32(blocks, i * 4 + 0);
-        uint32_t k2 = derive_c_getblock32(blocks, i * 4 + 1);
-        uint32_t k3 = derive_c_getblock32(blocks, i * 4 + 2);
-        uint32_t k4 = derive_c_getblock32(blocks, i * 4 + 3);
+        uint32_t k1 = derive_c_getblock32(blocks, (i * 4) + 0);
+        uint32_t k2 = derive_c_getblock32(blocks, (i * 4) + 1);
+        uint32_t k3 = derive_c_getblock32(blocks, (i * 4) + 2);
+        uint32_t k4 = derive_c_getblock32(blocks, (i * 4) + 3);
 
         k1 *= c1;
         k1 = derive_c_rotl32(k1, 15);
@@ -148,7 +150,7 @@ void derive_c_MurmurHash3_x86_128(const void* key, const int len, uint32_t seed,
 
     // tail
 
-    const uint8_t* tail = (const uint8_t*)(data + nblocks * 16);
+    const uint8_t* tail = (const uint8_t*)(data + (ptrdiff_t)(nblocks * 16));
 
     uint32_t k1 = 0;
     uint32_t k2 = 0;
@@ -205,6 +207,7 @@ void derive_c_MurmurHash3_x86_128(const void* key, const int len, uint32_t seed,
         k1 = derive_c_rotl32(k1, 15);
         k1 *= c2;
         h1 ^= k1;
+    default:
     };
 
     // finalization
@@ -239,9 +242,9 @@ void derive_c_MurmurHash3_x86_128(const void* key, const int len, uint32_t seed,
     ((uint32_t*)out)[3] = h4;
 }
 
-void derive_c_MurmurHash3_x64_128(const void* key, const int len, const uint32_t seed, void* out) {
+void derive_c_MurmurHash3_x64_128(const void* key, const int32_t len, const uint32_t seed, void* out) {
     const uint8_t* data = (const uint8_t*)key;
-    const int nblocks = len / 16;
+    const int32_t nblocks = len / 16;
 
     uint64_t h1 = seed;
     uint64_t h2 = seed;
@@ -253,9 +256,9 @@ void derive_c_MurmurHash3_x64_128(const void* key, const int len, const uint32_t
 
     const uint64_t* blocks = (const uint64_t*)(data);
 
-    for (int i = 0; i < nblocks; i++) {
-        uint64_t k1 = derive_c_getblock64(blocks, i * 2 + 0);
-        uint64_t k2 = derive_c_getblock64(blocks, i * 2 + 1);
+    for (int32_t i = 0; i < nblocks; i++) {
+        uint64_t k1 = derive_c_getblock64(blocks, (i * 2) + 0);
+        uint64_t k2 = derive_c_getblock64(blocks, (i * 2) + 1);
 
         k1 *= c1;
         k1 = derive_c_rotl64(k1, 31);
@@ -278,7 +281,7 @@ void derive_c_MurmurHash3_x64_128(const void* key, const int len, const uint32_t
 
     // tail
 
-    const uint8_t* tail = (const uint8_t*)(data + nblocks * 16);
+    const uint8_t* tail = (const uint8_t*)(data + (ptrdiff_t)(nblocks * 16));
 
     uint64_t k1 = 0;
     uint64_t k2 = 0;
@@ -323,6 +326,7 @@ void derive_c_MurmurHash3_x64_128(const void* key, const int len, const uint32_t
         k1 = derive_c_rotl64(k1, 31);
         k1 *= c2;
         h1 ^= k1;
+    default:
     };
 
     // finalization
@@ -343,7 +347,7 @@ void derive_c_MurmurHash3_x64_128(const void* key, const int len, const uint32_t
     ((uint64_t*)out)[1] = h2;
 }
 
-size_t derive_c_murmurhash(const void* key, int len, uint32_t seed) {
+size_t derive_c_murmurhash(const void* key, int32_t len, uint32_t seed) {
 #if SIZE_MAX == UINT64_MAX
     // 64-bit platform: use the x64 128-bit variant, return lower 64 bits
     uint64_t out128[2];

--- a/src/derive-c/structures/hashmap/template.h
+++ b/src/derive-c/structures/hashmap/template.h
@@ -11,7 +11,9 @@
 #include <derive-c/structures/hashmap/utils.h>
 
 #ifndef K
+#ifndef __clang_analyzer__
 #error "Key type must be defined to for a hashmap template"
+#endif
 typedef struct {
     int x;
 } derive_c_parameter_key;
@@ -21,23 +23,30 @@ static void derive_c_parameter_key_delete(derive_c_parameter_key* key __attribut
 #endif
 
 #ifndef V
+#ifndef __clang_analyzer__
 #error "Value type must be defined to for a hashmap template"
+#endif
 typedef struct {
     int x;
 } derive_c_parameter_value;
 #define V derive_c_parameter_value
-static void derive_c_parameter_value_delete(derive_c_parameter_value* key __attribute__((unused))) {}
+static void derive_c_parameter_value_delete(derive_c_parameter_value* key __attribute__((unused))) {
+}
 #define V_DELETE derive_c_parameter_value_delete
 #endif
 
 #ifndef HASH
+#ifndef __clang_analyzer__
 #error "The hash function for K must be defined"
+#endif
 static size_t derive_c_parameter_hash(derive_c_parameter_key const* key);
 #define HASH derive_c_parameter_hash
 #endif
 
 #ifndef EQ
+#ifndef __clang_analyzer__
 #error "The equality function for K must be defined"
+#endif
 static bool derive_c_parameter_eq(derive_c_parameter_key const* key_1,
                                   derive_c_parameter_key const* key_2);
 #define EQ derive_c_parameter_eq
@@ -126,8 +135,8 @@ static void NAME(SELF, extend_capacity_for)(SELF* self, size_t expected_items) {
                 NAME(SELF, insert)(&new_map, entry->key, self->values[index]);
             }
         }
-        free(self->keys);
-        free(self->values);
+        free((void*)self->keys);
+        free((void*)self->values);
         *self = new_map;
     }
 }
@@ -376,8 +385,8 @@ static void NAME(SELF, delete)(SELF* self) {
         }
     }
 
-    free(self->keys);
-    free(self->values);
+    free((void*)self->keys);
+    free((void*)self->values);
 }
 
 #undef ITER

--- a/src/derive-c/structures/hashmap/template.h
+++ b/src/derive-c/structures/hashmap/template.h
@@ -16,7 +16,7 @@ typedef struct {
     int x;
 } derive_c_parameter_key;
 #define K derive_c_parameter_key
-static void derive_c_parameter_key_delete(derive_c_parameter_key*) {}
+static void derive_c_parameter_key_delete(derive_c_parameter_key* key __attribute__((unused))) {}
 #define K_DELETE derive_c_parameter_key_delete
 #endif
 
@@ -26,7 +26,7 @@ typedef struct {
     int x;
 } derive_c_parameter_value;
 #define V derive_c_parameter_value
-static void derive_c_parameter_value_delete(derive_c_parameter_value*) {}
+static void derive_c_parameter_value_delete(derive_c_parameter_value* key __attribute__((unused))) {}
 #define V_DELETE derive_c_parameter_value_delete
 #endif
 
@@ -201,9 +201,8 @@ static V* NAME(SELF, try_write)(SELF* self, K key) {
         if (entry->present) {
             if (EQ(&entry->key, &key)) {
                 return &self->values[index];
-            } else {
-                index = modulus_capacity(index + 1, self->capacity);
             }
+            index = modulus_capacity(index + 1, self->capacity);
         } else {
             return NULL;
         }
@@ -226,9 +225,8 @@ static V const* NAME(SELF, try_read)(SELF const* self, K key) {
         if (entry->present) {
             if (EQ(&entry->key, &key)) {
                 return &self->values[index];
-            } else {
-                index = modulus_capacity(index + 1, self->capacity);
             }
+            index = modulus_capacity(index + 1, self->capacity);
         } else {
             return NULL;
         }
@@ -267,7 +265,7 @@ static bool NAME(SELF, try_remove)(SELF* self, K key, V* destination) {
                 size_t check_index = modulus_capacity(free_index + 1, self->capacity);
                 KEY_ENTRY* check_entry = &self->keys[check_index];
 
-                while (check_entry->present && check_entry->distance_from_desired > 0) {
+                while (check_entry->present && (check_entry->distance_from_desired > 0)) {
                     free_entry->key = check_entry->key;
                     free_entry->distance_from_desired = check_entry->distance_from_desired - 1;
                     self->values[free_index] = self->values[check_index];
@@ -288,9 +286,8 @@ static bool NAME(SELF, try_remove)(SELF* self, K key, V* destination) {
                 free_entry->present = false;
 
                 return true;
-            } else {
-                index = modulus_capacity(index + 1, self->capacity);
             }
+            index = modulus_capacity(index + 1, self->capacity);
         } else {
             return false;
         }
@@ -340,9 +337,8 @@ static KV_PAIR const* NAME(ITER, next)(ITER* iter) {
             iter->index++;
         }
         return &iter->curr;
-    } else {
-        return NULL;
     }
+    return NULL;
 }
 
 static size_t NAME(ITER, position)(ITER const* iter) {
@@ -414,9 +410,8 @@ static KV_PAIR_CONST const* NAME(ITER_CONST, next)(ITER_CONST* iter) {
             iter->index++;
         }
         return &iter->curr;
-    } else {
-        return NULL;
     }
+    return NULL;
 }
 
 static size_t NAME(ITER_CONST, position)(ITER_CONST const* iter) {

--- a/src/derive-c/structures/hashmap/utils.h
+++ b/src/derive-c/structures/hashmap/utils.h
@@ -9,7 +9,7 @@ static inline bool is_power_of_2(size_t x) { return x != 0 && (x & (x - 1)) == 0
 
 static inline size_t apply_capacity_policy(size_t capacity) {
     // TODO(oliverkillane): play with overallocation policy
-    return next_power_of_2(capacity + capacity / 2);
+    return next_power_of_2(capacity + (capacity / 2));
 }
 
 static inline size_t modulus_capacity(size_t index, size_t capacity) {

--- a/src/derive-c/structures/option/template.h
+++ b/src/derive-c/structures/option/template.h
@@ -14,7 +14,7 @@ typedef struct {
     int x;
 } derive_c_parameter_t;
 #define T derive_c_parameter_t
-static void derive_c_parameter_t_delete(derive_c_parameter_t*) {}
+static void derive_c_parameter_t_delete(derive_c_parameter_t* key __attribute__((unused))) {}
 #define T_DELETE derive_c_parameter_t_delete
 #endif
 
@@ -38,18 +38,16 @@ static T* NAME(SELF, get)(SELF* self) {
     DEBUG_ASSERT(self);
     if (self->present) {
         return &self->value;
-    } else {
-        return NULL;
     }
+    return NULL;
 }
 
 static T const* NAME(SELF, get_const)(SELF const* self) {
     DEBUG_ASSERT(self);
     if (self->present) {
         return &self->value;
-    } else {
-        return NULL;
     }
+    return NULL;
 }
 
 static bool NAME(SELF, is_present)(SELF const* self) {

--- a/src/derive-c/structures/option/template.h
+++ b/src/derive-c/structures/option/template.h
@@ -9,7 +9,9 @@
 #include <derive-c/self.h>
 
 #ifndef T
+#ifndef __clang_analyzer__
 #error "The contained type must be defined"
+#endif
 typedef struct {
     int x;
 } derive_c_parameter_t;

--- a/src/derive-c/structures/staticvec/template.h
+++ b/src/derive-c/structures/staticvec/template.h
@@ -1,6 +1,7 @@
 /// @brief A vector storing the first N elements in-place, and optionally spilling additional
 /// elements to a heap vector.
 
+#include <stddef.h>
 #include <stdint.h>
 
 #include <derive-c/core.h>
@@ -8,7 +9,9 @@
 #include <derive-c/self.h>
 
 #ifndef T
+#ifndef __clang_analyzer__
 #error "The contained type must be defined for a vector template"
+#endif
 typedef struct {
     int x;
 } derive_c_parameter_t;
@@ -22,7 +25,9 @@ static void derive_c_parameter_t_delete(derive_c_parameter_t* key __attribute__(
 #endif
 
 #ifndef INPLACE_CAPACITY
+#ifndef __clang_analyzer__
 #error "The number of elements to store in-place must be defined"
+#endif
 #define INPLACE_CAPACITY 8
 #endif
 

--- a/src/derive-c/structures/staticvec/template.h
+++ b/src/derive-c/structures/staticvec/template.h
@@ -13,7 +13,7 @@ typedef struct {
     int x;
 } derive_c_parameter_t;
 #define T derive_c_parameter_t // Allows independent debugging
-static void derive_c_parameter_t_delete(derive_c_parameter_t*) {}
+static void derive_c_parameter_t_delete(derive_c_parameter_t* key __attribute__((unused))) {}
 #define T_DELETE derive_c_parameter_t_delete
 #endif
 
@@ -59,9 +59,8 @@ static T const* NAME(SELF, try_read)(SELF const* self, INPLACE_TYPE index) {
     DEBUG_ASSERT(self);
     if (LIKELY(index < self->size)) {
         return &self->data[index];
-    } else {
-        return NULL;
     }
+    return NULL;
 }
 
 static T const* NAME(SELF, read)(SELF const* self, INPLACE_TYPE index) {
@@ -74,9 +73,8 @@ static T* NAME(SELF, try_write)(SELF* self, INPLACE_TYPE index) {
     DEBUG_ASSERT(self);
     if (LIKELY(index < self->size)) {
         return &self->data[index];
-    } else {
-        return NULL;
     }
+    return NULL;
 }
 
 static T* NAME(SELF, write)(SELF* self, INPLACE_TYPE index) {
@@ -92,9 +90,8 @@ static T* NAME(SELF, try_push)(SELF* self, T value) {
         *slot = value;
         self->size++;
         return slot;
-    } else {
-        return NULL;
     }
+    return NULL;
 }
 
 static T* NAME(SELF, push)(SELF* self, T value) {
@@ -109,9 +106,8 @@ static bool NAME(SELF, try_pop)(SELF* self, T* destination) {
         self->size--;
         *destination = self->data[self->size];
         return true;
-    } else {
-        return false;
     }
+    return false;
 }
 
 static T NAME(SELF, pop)(SELF* self) {
@@ -145,9 +141,8 @@ static T* NAME(ITER, next)(ITER* iter) {
         T* item = &iter->vec->data[iter->pos];
         iter->pos++;
         return item;
-    } else {
-        return NULL;
     }
+    return NULL;
 }
 
 static size_t NAME(ITER, position)(ITER const* iter) {
@@ -183,9 +178,8 @@ static T const* NAME(ITER_CONST, next)(ITER_CONST* iter) {
         T const* item = &iter->vec->data[iter->pos];
         iter->pos++;
         return item;
-    } else {
-        return NULL;
     }
+    return NULL;
 }
 
 static size_t NAME(ITER_CONST, position)(ITER_CONST const* iter) {

--- a/src/derive-c/structures/vector/template.h
+++ b/src/derive-c/structures/vector/template.h
@@ -11,12 +11,14 @@
 #include <derive-c/self.h>
 
 #ifndef T
+#ifndef __clang_analyzer__
 #error "The contained type must be defined for a vector template"
+#endif
 typedef struct {
     int x;
 } derive_c_parameter_t;
 #define T derive_c_parameter_t // Allows independent debugging
-static void derive_c_parameter_t_delete(derive_c_parameter_t*) {}
+static void derive_c_parameter_t_delete(derive_c_parameter_t* t __attribute__((unused))) {}
 #define T_DELETE derive_c_parameter_t_delete
 #endif
 

--- a/src/derive-c/structures/vector/template.h
+++ b/src/derive-c/structures/vector/template.h
@@ -80,9 +80,8 @@ static T const* NAME(SELF, try_read)(SELF const* self, size_t index) {
     DEBUG_ASSERT(self);
     if (LIKELY(index < self->size)) {
         return &self->data[index];
-    } else {
-        return NULL;
     }
+    return NULL;
 }
 
 static T const* NAME(SELF, read)(SELF const* self, size_t index) {
@@ -95,9 +94,8 @@ static T* NAME(SELF, try_write)(SELF* self, size_t index) {
     DEBUG_ASSERT(self);
     if (LIKELY(index < self->size)) {
         return &self->data[index];
-    } else {
-        return NULL;
     }
+    return NULL;
 }
 
 static T* NAME(SELF, write)(SELF* self, size_t index) {
@@ -142,9 +140,8 @@ static bool NAME(SELF, try_pop)(SELF* self, T* destination) {
         self->size--;
         *destination = self->data[self->size];
         return true;
-    } else {
-        return false;
     }
+    return false;
 }
 
 static T NAME(SELF, pop)(SELF* self) {
@@ -179,9 +176,8 @@ static T* NAME(ITER, next)(ITER* iter) {
         T* item = &iter->vec->data[iter->pos];
         iter->pos++;
         return item;
-    } else {
-        return NULL;
     }
+    return NULL;
 }
 
 static size_t NAME(ITER, position)(ITER const* iter) {
@@ -216,9 +212,8 @@ static T const* NAME(ITER_CONST, next)(ITER_CONST* iter) {
         T const* item = &iter->vec->data[iter->pos];
         iter->pos++;
         return item;
-    } else {
-        return NULL;
     }
+    return NULL;
 }
 
 static size_t NAME(ITER_CONST, position)(ITER_CONST const* iter) {

--- a/test/arena.cpp
+++ b/test/arena.cpp
@@ -70,8 +70,8 @@ struct SutWrapper {
         return *this;
     }
 
-    Sut* get() { return &sut; }
-    Sut const* getConst() const { return &sut; }
+    [[nodiscard]] Sut* get() { return &sut; }
+    [[nodiscard]] Sut const* getConst() const { return &sut; }
 
     Sut sut;
     std::unordered_map<ModelIndex, Sut_index> indexToSutIndex;

--- a/test/hashmap.cpp
+++ b/test/hashmap.cpp
@@ -17,11 +17,11 @@ extern "C" {
 bool key_equality(Key const* key_1, Key const* key_2) { return *key_1 == *key_2; }
 Key key_hash(Key const* key) {
     // Bad hash exposes more collisions in the map
+    constexpr size_t SMALL_MOD = 1000;
     if (*key % 2 == 0) {
-        return 1000 + (*key % 1000);
-    } else {
-        return 0;
+        return SMALL_MOD + (*key % SMALL_MOD);
     }
+    return 0;
 }
 
 #define K Key
@@ -45,8 +45,8 @@ struct SutWrapper {
         return *this;
     }
 
-    Sut* get() { return &sut; }
-    Sut const* getConst() const { return &sut; }
+    [[nodiscard]] Sut* get() { return &sut; }
+    [[nodiscard]] Sut const* getConst() const { return &sut; }
 
     Sut sut;
 };

--- a/test/vector.cpp
+++ b/test/vector.cpp
@@ -18,16 +18,16 @@ extern "C" {
 #include <derive-c/structures/vector/template.h>
 }
 
+static const int MAX_SIZE = 100;
 Sut newSut(size_t size) {
     if (size == 0) {
         return Sut_new();
-    } else {
-        return Sut_new_with_capacity(size);
     }
+    return Sut_new_with_capacity(size);
 }
 
 struct SutWrapper {
-    SutWrapper() : sut(newSut(*rc::gen::inRange(0, 100))) {}
+    SutWrapper() : sut(newSut(*rc::gen::inRange(0, MAX_SIZE))) {}
     ~SutWrapper() { Sut_delete(&sut); }
     SutWrapper(const Sut& sut) : sut(Sut_shallow_clone(&sut)) {}
     SutWrapper& operator=(const SutWrapper& other) {
@@ -38,8 +38,8 @@ struct SutWrapper {
         return *this;
     }
 
-    Sut* get() { return &sut; }
-    Sut const* getConst() const { return &sut; }
+    [[nodiscard]] Sut* get() { return &sut; }
+    [[nodiscard]] Sut const* getConst() const { return &sut; }
 
     Sut sut;
 };


### PR DESCRIPTION
## Context
Only formatting currently, no linting checks = inconsistent style.

## Goals
 - [x] Add clang tidy linting for c & cpp code here
 - [x] Lint C code in CI
 
## Changes
 - Made format & lint normal tests, no special stage in ci
 - Fixed missing includes spotted by clang-tidy
 - No error from param check `#error`s during linting of the template files