### PR TITLE
Add a test allocator

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ int main() {
 
 ## Use
 In a `CMakeLists.txt`
-```cmake
+```
 include(FetchContent)
 
 FetchContent_Declare(

--- a/examples/complex/readme.c
+++ b/examples/complex/readme.c
@@ -13,8 +13,8 @@ int main() {
     alloc_2048 alloc = alloc_2048_new();
     vec_char vec = vec_char_new(&alloc);
 
-    for (char x = '1'; x <= '9'; x++) {
-        vec_char_push(&vec, x);
+    for (char x = 1; x <= 9; x++) {
+        vec_char_push(&vec, (char)('0' + x));
     }
 
     vec_char_iter_const iter = vec_char_get_iter_const(&vec);

--- a/src/derive-c/allocs/null.h
+++ b/src/derive-c/allocs/null.h
@@ -19,23 +19,25 @@ typedef struct {
 
 static nullalloc NAME(nullalloc, get)() { return (nullalloc){}; }
 
-static void* NAME(nullalloc, malloc)(nullalloc* self, size_t size) {
+static void* NAME(nullalloc, malloc)(nullalloc* DEBUG_UNUSED(self), size_t UNUSED(size)) {
     DEBUG_ASSERT(self);
     return NULL;
 }
 
-static void* NAME(nullalloc, realloc)(nullalloc* self, void* ptr, size_t size) {
+static void* NAME(nullalloc, realloc)(nullalloc* DEBUG_UNUSED(self), void* DEBUG_UNUSED(ptr),
+                                      size_t UNUSED(size)) {
     DEBUG_ASSERT(self);
     DEBUG_ASSERT(ptr);
     return NULL;
 }
 
-static void* NAME(nullalloc, calloc)(nullalloc* self, size_t count, size_t size) {
+static void* NAME(nullalloc, calloc)(nullalloc* DEBUG_UNUSED(self), size_t UNUSED(count),
+                                     size_t UNUSED(size)) {
     DEBUG_ASSERT(self);
     return NULL;
 }
 
-static void NAME(nullalloc, free)(nullalloc* self, void* ptr) {
+static void NAME(nullalloc, free)(nullalloc* DEBUG_UNUSED(self), void* UNUSED(ptr)) {
     DEBUG_ASSERT(self);
     PANIC("Not possible to free memory from the null allocator, as it allocates nothing")
 }

--- a/src/derive-c/allocs/staticbump/template.h
+++ b/src/derive-c/allocs/staticbump/template.h
@@ -51,7 +51,7 @@ static SELF NAME(SELF, new)() {
 static void NAME(SELF, clear)(SELF* self) {
     DEBUG_ASSERT(self);
 
-#ifdef NDEBUG
+#ifndef NDEBUG
     // JUSTIFY: Allocations & sizes zeroed on free in debug, we check all data has been freed.
     for (size_t i = 0; i < self->used; i++) {
         if (self->buffer[i] != 0) {
@@ -84,13 +84,12 @@ static void NAME(SELF, free)(SELF* DEBUG_UNUSED(self), void* DEBUG_UNUSED(ptr)) 
     DEBUG_ASSERT(self);
     DEBUG_ASSERT(ptr);
 
-#ifdef NDEBUG
+#ifndef NDEBUG
     // JUSTIFY: Zero memory in debug.
     //           - Expensive for release, but helpful when debugging
     // NOTE: This means that users should free, before they clear and reuse the buffer.
-    USED* used_ptr = (USED*)(ptr - sizeof(USED));
-    *used_ptr;
-    memset(ptr, *used_ptr, 0);
+    USED* used_ptr = (USED*)((char*)ptr - sizeof(USED));
+    memset(ptr, 0, *used_ptr);
     *used_ptr = 0;
 #endif
 }

--- a/src/derive-c/allocs/test/template.h
+++ b/src/derive-c/allocs/test/template.h
@@ -1,0 +1,144 @@
+/// @brief For unit tests expected to throw, as C has no unwind, we cannot free allocated memory.
+///        This macro wraps the allocator in debug, to allow clearing leaks after an exception.
+/// 
+/// In release, it is a no-op / pass through.
+
+#include <derive-c/core.h>
+#include <derive-c/panic.h>
+#include <derive-c/self.h>
+#include <derive-c/allocs/std.h>
+
+#ifndef ALLOC
+#ifndef __clang_analyzer__
+#error "The allocator being wrapped must be defined"
+#endif
+#include <derive-c/allocs/null.h>
+#define ALLOC nullalloc
+#endif 
+
+#ifndef ENTRIES
+#ifndef __clang_analyzer__
+#error "The name of the type to generate for storing entries must be defined"
+#endif
+#define ENTRIES derive_c_entries_placeholder_name
+#endif
+
+#ifndef NDEBUG
+
+typedef struct {
+    ALLOC* alloc;
+} SELF;
+
+static SELF NAME(SELF, new)(ALLOC* alloc) {
+    return (SELF){.alloc = alloc};
+}
+
+static void* NAME(SELF, malloc)(SELF* self, size_t size) {
+    return NAME(ALLOC, malloc)(self->alloc, size);
+}
+
+static void* NAME(SELF, calloc)(SELF* self, size_t count, size_t size) {
+    return NAME(ALLOC, calloc)(self->alloc, count, size);
+}
+
+static void* NAME(SELF, realloc)(SELF* self, void* ptr, size_t size) {
+    return NAME(ALLOC, realloc)(self->alloc, ptr, size);
+}
+
+static void NAME(SELF, free)(SELF* self, void* ptr) {
+    return NAME(ALLOC, free)(self->alloc, ptr);
+}
+
+#else
+
+#define TRACKED_ENTRY NAME(ENTRIES, entry)
+
+typedef struct {
+    void* ptr;
+    bool freed;
+} TRACKED_ENTRY;
+
+#pragma push_macro("SELF")
+#undef SELF
+
+// JUSTIFY: Using a vector rather than a faster lookup map.
+//           - Give this will be used for test & debug, performance matters less
+//           - Much easier to explore a vector, than a hashmap in gdb. 
+#define T TRACKED_ENTRY
+#define SELF ENTRIES
+#include <derive-c/structures/vector/template.h>
+
+#pragma pop_macro("SELF")
+
+typedef struct {
+    ALLOC* alloc;
+    ENTRIES entries;
+} SELF;
+
+static SELF NAME(SELF, new)(ALLOC* alloc) {
+    return (SELF){.alloc = alloc, .entries = NAME(ENTRIES, new)(stdalloc_get())};
+}
+
+static ENTRIES const* NAME(SELF, get_entries)(SELF const* self) {
+    DEBUG_ASSERT(self);
+    return &self->entries;
+}
+
+static void NAME(SELF, unleak)(SELF* self) {
+    NAME(ENTRIES, iter) iter = NAME(ENTRIES, get_iter)(&self->entries);
+    TRACKED_ENTRY* entry;
+
+    while ((entry = NAME(ENTRIES, iter_next)(&iter))) {
+        if (!entry->freed) {
+            NAME(ALLOC, free)(self->alloc, entry->ptr);
+        }
+    }
+}
+
+static void* NAME(SELF, calloc)(SELF* self, size_t count, size_t size) {
+    DEBUG_ASSERT(self);
+    void* ptr = NAME(ALLOC, calloc)(self->alloc, count, size);
+    if (ptr) {
+        TRACKED_ENTRY entry = {.ptr = ptr, .freed = false};
+        NAME(ENTRIES, push_back)(&self->entries, entry);
+    }
+    return ptr;
+}
+
+static void* NAME(SELF, malloc)(SELF* self, size_t size) {
+    // JUSTIFY: All mallocs are actually callocs:
+    //           - easier for testing & debugging, which is the purpose of this allocator
+    return NAME(SELF, calloc)(self->alloc, size);
+}
+
+static void* NAME(SELF, realloc)(SELF* self, void* ptr, size_t size) {
+    DEBUG_ASSERT(self);
+    DEBUG_ASSERT(ptr);
+    return NAME(ALLOC, realloc)(self->alloc, ptr, size);
+}
+
+static void NAME(SELF, free)(SELF* self, void* ptr) {
+    DEBUG_ASSERT(ptr);
+    DEBUG_ASSERT(self);
+
+    NAME(ENTRIES, iter) iter = NAME(ENTRIES, get_iter)(&self->entries);
+    TRACKED_ENTRY* entry;
+
+    while ((entry = NAME(ENTRIES, iter_next)(&iter))) {
+        if (entry->ptr == ptr) {
+            DEBUG_ASSERT(!entry->freed);
+            entry->freed = true;
+            break;
+        }
+    }
+
+    NAME(ALLOC, free)(self->alloc, ptr);
+}
+
+#undef ENTRIES
+#undef TRACKED_ENTRY
+
+#endif
+
+#undef SELF
+

--- a/src/derive-c/core.h
+++ b/src/derive-c/core.h
@@ -4,10 +4,10 @@
 #define NAME_EXPANDED(pre, post) pre##_##post
 #define NAME(pre, post) NAME_EXPANDED(pre, post)
 
-#ifdef NDEBUG
+#ifndef NDEBUG
 #define DEBUG_UNUSED(ident) ident __attribute__((unused))
 #else
-#define DEBUG_UNUSED(ident) ident __attribute__((unused))
+#define DEBUG_UNUSED(ident)
 #endif
 
 #define UNUSED(ident) ident __attribute__((unused))

--- a/src/derive-c/panic.h
+++ b/src/derive-c/panic.h
@@ -19,7 +19,7 @@
     }
 #endif
 
-#ifdef NDEBUG
+#ifndef NDEBUG
 #define DEBUG_ASSERT(expr) ASSERT(expr)
 #else
 #define DEBUG_ASSERT(expr)

--- a/src/derive-c/structures/vector/template.h
+++ b/src/derive-c/structures/vector/template.h
@@ -169,10 +169,12 @@ static size_t NAME(SELF, size)(SELF const* self) {
 
 static void NAME(SELF, delete)(SELF* self) {
     DEBUG_ASSERT(self);
-    for (size_t i = 0; i < self->size; i++) {
-        T_DELETE(&self->data[i]);
+    if (self->data) {
+        for (size_t i = 0; i < self->size; i++) {
+            T_DELETE(&self->data[i]);
+        }
+        NAME(ALLOC, free)(self->alloc, self->data);
     }
-    NAME(ALLOC, free)(self->alloc, self->data);
 }
 
 #define ITER NAME(SELF, iter)

--- a/test/allocs/test.cpp
+++ b/test/allocs/test.cpp
@@ -1,0 +1,28 @@
+#include <gtest/gtest.h>
+
+namespace testalloc {
+
+#define PANIC(msg) throw std::runtime_error(std::format(msg))
+
+extern "C" {
+#include <derive-c/allocs/std.h>
+
+#define ALLOC stdalloc
+#define ENTRIES allocs
+#define SELF stdtestalloc
+#include <derive-c/allocs/test/template.h>
+
+void allocate_and_throw(stdtestalloc* alloc) {
+    void* a = stdtestalloc_malloc(alloc, 10000000);
+    ((int*)a)[12] = 42;
+    PANIC("prblem!");
+}
+}
+
+TEST(TestAlloc, BasicAllocation) {
+    stdtestalloc alloc = stdtestalloc_new(stdalloc_get());
+    EXPECT_ANY_THROW(allocate_and_throw(&alloc));
+    stdtestalloc_unleak_and_delete(&alloc);
+}
+
+} // namespace testalloc

--- a/test/structures/vector.cpp
+++ b/test/structures/vector.cpp
@@ -135,7 +135,7 @@ TEST(VectorTests, CreateWithDefaults) {
 }
 
 TEST(VectorTests, CreateWithZeroSize) {
-    Sut sut_1 = Sut_new_with_capacity(0, stdalloc_get());
+    Sut sut_1 = Sut_new(stdalloc_get());
     ASSERT_EQ(Sut_size(&sut_1), 0);
     Sut_delete(&sut_1);
 


### PR DESCRIPTION
## Context
When unit tests expect death, allocations are leaked as C has no unwind.
 - As a result, leak checks need to be turned off to pass
 - Meaning dangerous leaks can be missed

To fix this, a new allocator that wraps another, allows for free all allocations through it is required.

## Goals
 - [x] Add a basic test allocator
 - [x] Add unit tests that throw, but do not leak. 