### PR TITLE
Added cpu feature detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,12 @@ if (CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "")
   set(_dbg_default ON)
 endif()
 
+if (CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
+  add_compile_options(
+    $<$<C_COMPILER_ID:GNU,Clang>:-march=native>
+    $<$<CXX_COMPILER_ID:GNU,Clang>:-march=native>)
+endif()
+
 option(USE_ASAN  "Enable AddressSanitizer (ASan)"            ${_dbg_default})
 option(USE_UBSAN "Enable UndefinedBehaviorSanitizer (UBSan)" ${_dbg_default})
 option(USE_MSAN  "Enable MemorySanitizer (MSan)"             OFF)

--- a/examples/complex/prime_sieve.c
+++ b/examples/complex/prime_sieve.c
@@ -79,6 +79,9 @@ static void compute(sieve_vec* sieve) {
 }
 
 int main() {
+    // Check cpu features we have enabled
+    dc_cpu_features_dump(stdout);
+
     size_t up_to = 28;
     DC_ASSERT(up_to < MAX_UP_TO);
     printf("Listing primes up to: %zu\n", up_to);

--- a/src/derive-c/core/compiler.h
+++ b/src/derive-c/core/compiler.h
@@ -1,4 +1,5 @@
 #pragma once
+
 // JUSTIFY: Allowing _Generic with clang
 //  - Tests are in C++, we ideally want all the code to be compiled as C
 //  - In the matrix build, GCC will validate the templated versions, clang the _Generic

--- a/src/derive-c/core/cpu_features.h
+++ b/src/derive-c/core/cpu_features.h
@@ -6,7 +6,7 @@
 #include <derive-c/core/debug/fmt.h>
 #include <derive-c/core/traits/debug.h>
 
-#define _DC_CPU_FEATURES(F)                                                                            \
+#define _DC_CPU_FEATURES(F)                                                                        \
     F(SSE, "sse")                                                                                  \
     F(SSE2, "sse2")                                                                                \
     F(SSE3, "sse3")                                                                                \
@@ -37,7 +37,7 @@ typedef struct {
 
 static dc_cpu_features dc_cpu_features_get() {
     return (dc_cpu_features){
-#define _DC_FEATURE_DETECT(feature_name, runtime_name)                                                 \
+#define _DC_FEATURE_DETECT(feature_name, runtime_name)                                             \
     .feature_name = {.name = runtime_name,                                                         \
                      .compiled_with = DC_IS_DEFINED(__##feature_name##__),                         \
                      .runtime_supported = (bool)__builtin_cpu_supports(runtime_name)},
@@ -51,7 +51,7 @@ DC_PUBLIC static void dc_cpu_features_debug(dc_cpu_features const* self, dc_debu
     (void)fmt;
     fprintf(stream, "| %-12s | %-8s | %-8s |\n", "feature", "compiler", "runtime");
     fprintf(stream, "| %-12s | %-8s | %-8s |\n", "------------", "--------", "--------");
-#define _DC_FEATURE_ROW(feature, _)                                                                    \
+#define _DC_FEATURE_ROW(feature, _)                                                                \
     fprintf(stream, "| %-12s | %-8s | %-8s |\n", self->feature.name,                               \
             self->feature.compiled_with ? "yes" : "no",                                            \
             self->feature.runtime_supported ? "yes" : "no");

--- a/src/derive-c/core/cpu_features.h
+++ b/src/derive-c/core/cpu_features.h
@@ -6,7 +6,7 @@
 #include <derive-c/core/debug/fmt.h>
 #include <derive-c/core/traits/debug.h>
 
-#define CPU_FEATURES(F)                                                                            \
+#define _DC_CPU_FEATURES(F)                                                                            \
     F(SSE, "sse")                                                                                  \
     F(SSE2, "sse2")                                                                                \
     F(SSE3, "sse3")                                                                                \
@@ -30,19 +30,19 @@ typedef struct {
 } dc_cpu_feature;
 
 typedef struct {
-#define FEATURE_DECLARE(name, _) dc_cpu_feature name;
-    CPU_FEATURES(FEATURE_DECLARE)
-#undef FEATURE_DECLARE
+#define _DC_FEATURE_DECLARE(name, _) dc_cpu_feature name;
+    _DC_CPU_FEATURES(_DC_FEATURE_DECLARE)
+#undef _DC_FEATURE_DECLARE
 } dc_cpu_features;
 
 static dc_cpu_features dc_cpu_features_get() {
     return (dc_cpu_features){
-#define FEATURE_DETECT(feature_name, runtime_name)                                                 \
+#define _DC_FEATURE_DETECT(feature_name, runtime_name)                                                 \
     .feature_name = {.name = runtime_name,                                                         \
                      .compiled_with = DC_IS_DEFINED(__##feature_name##__),                         \
                      .runtime_supported = (bool)__builtin_cpu_supports(runtime_name)},
-        CPU_FEATURES(FEATURE_DETECT)
-#undef FEATURE_DETECT
+        _DC_CPU_FEATURES(_DC_FEATURE_DETECT)
+#undef _DC_FEATURE_DETECT
     };
 }
 
@@ -51,12 +51,12 @@ DC_PUBLIC static void dc_cpu_features_debug(dc_cpu_features const* self, dc_debu
     (void)fmt;
     fprintf(stream, "| %-12s | %-8s | %-8s |\n", "feature", "compiler", "runtime");
     fprintf(stream, "| %-12s | %-8s | %-8s |\n", "------------", "--------", "--------");
-#define FEATURE_ROW(feature, _)                                                                    \
+#define _DC_FEATURE_ROW(feature, _)                                                                    \
     fprintf(stream, "| %-12s | %-8s | %-8s |\n", self->feature.name,                               \
             self->feature.compiled_with ? "yes" : "no",                                            \
             self->feature.runtime_supported ? "yes" : "no");
-    CPU_FEATURES(FEATURE_ROW)
-#undef FEATURE_ROW
+    _DC_CPU_FEATURES(_DC_FEATURE_ROW)
+#undef _DC_FEATURE_ROW
     fprintf(stream, "\n");
 }
 

--- a/src/derive-c/core/cpu_features.h
+++ b/src/derive-c/core/cpu_features.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <stdbool.h>
+#include <stdio.h>
+
+#include <derive-c/core/debug/fmt.h>
+#include <derive-c/core/traits/debug.h>
+
+#define CPU_FEATURES(F)                                                                            \
+    F(SSE, "sse")                                                                                  \
+    F(SSE2, "sse2")                                                                                \
+    F(SSE3, "sse3")                                                                                \
+    F(SSSE3, "ssse3")                                                                              \
+    F(SSE4_1, "sse4.1")                                                                            \
+    F(SSE4_2, "sse4.2")                                                                            \
+    F(AVX, "avx")                                                                                  \
+    F(AVX2, "avx2")                                                                                \
+    F(FMA, "fma")                                                                                  \
+    F(BMI, "bmi")                                                                                  \
+    F(BMI2, "bmi2")                                                                                \
+    F(AES, "aes")                                                                                  \
+    F(PCLMUL, "pclmul")                                                                            \
+    F(POPCNT, "popcnt")                                                                            \
+    F(LZCNT, "lzcnt")
+
+typedef struct {
+    char const* name;
+    bool const compiled_with;
+    bool const runtime_supported;
+} dc_cpu_feature;
+
+typedef struct {
+#define FEATURE_DECLARE(name, _) dc_cpu_feature name;
+    CPU_FEATURES(FEATURE_DECLARE)
+#undef FEATURE_DECLARE
+} dc_cpu_features;
+
+static dc_cpu_features dc_cpu_features_get() {
+    return (dc_cpu_features){
+#define FEATURE_DETECT(feature_name, runtime_name)                                                 \
+    .feature_name = {.name = runtime_name,                                                         \
+                     .compiled_with = DC_IS_DEFINED(__##feature_name##__),                         \
+                     .runtime_supported = __builtin_cpu_supports(runtime_name)},
+        CPU_FEATURES(FEATURE_DETECT)
+#undef FEATURE_DETECT
+    };
+}
+
+DC_PUBLIC static void dc_cpu_features_debug(dc_cpu_features const* self, dc_debug_fmt fmt,
+                                            FILE* stream) {
+    (void)fmt;
+    fprintf(stream, "| %-12s | %-8s | %-8s |\n", "feature", "compiler", "runtime");
+    fprintf(stream, "| %-12s | %-8s | %-8s |\n", "------------", "--------", "--------");
+#define FEATURE_ROW(feature, _)                                                                    \
+    fprintf(stream, "| %-12s | %-8s | %-8s |\n", self->feature.name,                               \
+            self->feature.compiled_with ? "yes" : "no",                                            \
+            self->feature.runtime_supported ? "yes" : "no");
+    CPU_FEATURES(FEATURE_ROW)
+#undef FEATURE_ROW
+    fprintf(stream, "\n");
+}
+
+DC_PUBLIC static void dc_cpu_features_dump(FILE* stream) {
+    dc_cpu_features features = dc_cpu_features_get();
+    dc_cpu_features_debug(&features, dc_debug_fmt_new(), stream);
+}

--- a/src/derive-c/core/cpu_features.h
+++ b/src/derive-c/core/cpu_features.h
@@ -40,7 +40,7 @@ static dc_cpu_features dc_cpu_features_get() {
 #define FEATURE_DETECT(feature_name, runtime_name)                                                 \
     .feature_name = {.name = runtime_name,                                                         \
                      .compiled_with = DC_IS_DEFINED(__##feature_name##__),                         \
-                     .runtime_supported = __builtin_cpu_supports(runtime_name)},
+                     .runtime_supported = (bool)__builtin_cpu_supports(runtime_name)},
         CPU_FEATURES(FEATURE_DETECT)
 #undef FEATURE_DETECT
     };

--- a/src/derive-c/core/namespace.h
+++ b/src/derive-c/core/namespace.h
@@ -5,6 +5,8 @@
 #define DC_STRINGIFY(MACRO) #MACRO
 #define DC_EXPAND_STRING(NAME) DC_STRINGIFY(NAME)
 
+#define DC_IS_DEFINED(MACRO) (sizeof(DC_STRINGIFY(MACRO)) != sizeof(#MACRO))
+
 // JUSTIFY: Not namespaced under `DC`
 //  - `NS` is everywhere - ugly if expanded to DC_NS, and not a name likely to
 //    conflict with others

--- a/src/derive-c/core/prelude.h
+++ b/src/derive-c/core/prelude.h
@@ -3,15 +3,16 @@
 #include <derive-c/core/panic.h> // IWYU pragma: export
 
 // Helpful
-#include <derive-c/core/attributes.h>  // IWYU pragma: export
-#include <derive-c/core/derive.h>      // IWYU pragma: export
-#include <derive-c/core/math.h>        // IWYU pragma: export
-#include <derive-c/core/namespace.h>   // IWYU pragma: export
-#include <derive-c/core/placeholder.h> // IWYU pragma: export
-#include <derive-c/core/require.h>     // IWYU pragma: export
-#include <derive-c/core/scope.h>       // IWYU pragma: export
-#include <derive-c/core/zerosized.h>   // IWYU pragma: export
-#include <derive-c/core/unit.h>        // IWYU pragma: export
+#include <derive-c/core/attributes.h>   // IWYU pragma: export
+#include <derive-c/core/derive.h>       // IWYU pragma: export
+#include <derive-c/core/math.h>         // IWYU pragma: export
+#include <derive-c/core/namespace.h>    // IWYU pragma: export
+#include <derive-c/core/placeholder.h>  // IWYU pragma: export
+#include <derive-c/core/require.h>      // IWYU pragma: export
+#include <derive-c/core/scope.h>        // IWYU pragma: export
+#include <derive-c/core/zerosized.h>    // IWYU pragma: export
+#include <derive-c/core/unit.h>         // IWYU pragma: export
+#include <derive-c/core/cpu_features.h> // IWYU pragma: export
 
 // Traits
 #include <derive-c/core/traits/clone.h>  // IWYU pragma: export

--- a/test/core/prelude/cpu_features/test.cpp
+++ b/test/core/prelude/cpu_features/test.cpp
@@ -1,0 +1,54 @@
+
+#include <gtest/gtest.h>
+
+#include <derive-c/core/prelude.h>
+#include <derive-c/utils/debug/string.h>
+
+TEST(CoreTests, CpuFeaturesDebugToString) {
+    dc_cpu_features features = {
+        .SSE = {"sse", true, true},
+        .SSE2 = {"sse2", true, false},
+        .SSE3 = {"sse3", false, true},
+        .SSSE3 = {"ssse3", false, false},
+        .SSE4_1 = {"sse4.1", true, true},
+        .SSE4_2 = {"sse4.2", true, false},
+        .AVX = {"avx", false, true},
+        .AVX2 = {"avx2", false, false},
+        .FMA = {"fma", true, true},
+        .BMI = {"bmi", true, false},
+        .BMI2 = {"bmi2", false, true},
+        .AES = {"aes", false, false},
+        .PCLMUL = {"pclmul", true, true},
+        .POPCNT = {"popcnt", true, false},
+        .LZCNT = {"lzcnt", false, true},
+    };
+
+    DC_SCOPED(dc_debug_string_builder) sb = dc_debug_string_builder_new(stdalloc_get_ref());
+    dc_cpu_features_debug(&features, dc_debug_fmt_new(), dc_debug_string_builder_stream(&sb));
+
+    char const* str = dc_debug_string_builder_string(&sb);
+    ASSERT_NE(str, nullptr);
+
+    char const* expected =
+        // clang-format off
+        "| feature      | compiler | runtime  |\n"
+        "| ------------ | -------- | -------- |\n"
+        "| sse          | yes      | yes      |\n"
+        "| sse2         | yes      | no       |\n"
+        "| sse3         | no       | yes      |\n"
+        "| ssse3        | no       | no       |\n"
+        "| sse4.1       | yes      | yes      |\n"
+        "| sse4.2       | yes      | no       |\n"
+        "| avx          | no       | yes      |\n"
+        "| avx2         | no       | no       |\n"
+        "| fma          | yes      | yes      |\n"
+        "| bmi          | yes      | no       |\n"
+        "| bmi2         | no       | yes      |\n"
+        "| aes          | no       | no       |\n"
+        "| pclmul       | yes      | yes      |\n"
+        "| popcnt       | yes      | no       |\n"
+        "| lzcnt        | no       | yes      |\n"
+        "\n";
+    // clang-format on
+    EXPECT_STREQ(str, expected);
+}


### PR DESCRIPTION
## Context
When running benchmarks, we are not running with the latest & greatest features supported the CPU. We need a way to check compiled & cpu supported features.

## Goals
 - [x] Add a method for getting, and printing cpu vs compiled features
 - [x] Added to an example

## Additional Changes
 - 

## Testing
<!-- All testing should always be in CI, care should be taken to instantiate templates with different types -->
 - [ ] Added necessary tests and checked `ninja coverage` (see CI coverage artifact)
 - [ ] Check api (using `_dc` & `PRIV(..)` for private, functions correctly marked as `DC_PUBLIC` or `DC_INTERNAL`)
